### PR TITLE
Removed autogenerated constructor comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 
 # Persistence
 persistence.xml
+/target/

--- a/src/controller/CoursesHelper.java
+++ b/src/controller/CoursesHelper.java
@@ -22,7 +22,7 @@ public class CoursesHelper {
 	 * Default constructor.
 	*/
 	public CoursesHelper() {
-	// TODO Auto-generated constructor stub
+
 	}
 		
 	/**

--- a/src/controller/InstructorsHelper.java
+++ b/src/controller/InstructorsHelper.java
@@ -20,7 +20,7 @@ public class InstructorsHelper {
 	 * Default constructor.
 	 */
 	public InstructorsHelper() {
-		// TODO Auto-generated constructor stub
+
 	}
 	
 	/**


### PR DESCRIPTION
Removed comments that read "// TODO Auto-generated constructor stub" from CoursesHelper and InstructorsHelper. These just feel unnecessary and look make the code look un-polished, IMO.